### PR TITLE
feat: enhance CourseRevisionTabs with detailed course data mapping

### DIFF
--- a/src/components/dean-components/revision-review-components/ProgramRevisionReview.tsx
+++ b/src/components/dean-components/revision-review-components/ProgramRevisionReview.tsx
@@ -21,6 +21,7 @@ import {
   TransformedProgramData,
   transformProposalData,
 } from "@/components/dean-components/revision-review-components/types";
+import { CourseData } from "./revision-tabs/revisionType";
 
 import { ProgramDetails } from "@/components/dean-components/revision-review-components/ProgramDetails";
 import { ProgramEducationalObjectives } from "@/components/dean-components/revision-review-components/PEO";
@@ -649,7 +650,13 @@ export default function ProgramRevisionReview({
           {/* Course Revisions Tab */}
           <TabsContent value="courses" className="space-y-4">
             <CourseRevisionTabs
-              coursesWithRevisions={coursesWithRevisions || []}
+              coursesWithRevisions={coursesWithRevisions.map((course) => ({
+                curriculum_course_id: course.curriculum_course_id,
+                course_code: course.course_code,
+                course_title: course.course_title,
+                revisions: course.revisions,
+                courseData: course.courseData as CourseData, // Add type assertion here
+              }))}
               openSections={openSections}
               toggleSection={toggleSection}
             />


### PR DESCRIPTION
This pull request introduces a type-related improvement and a functional update to the `ProgramRevisionReview` component in the `src/components/dean-components/revision-review-components` directory. The changes ensure better type safety and refine how course revision data is handled.

### Type Improvements:
* [`src/components/dean-components/revision-review-components/ProgramRevisionReview.tsx`](diffhunk://#diff-c636d9151b2bb3b919d6e370bb90cf3d1ff4b7eae039e8ca41e9c111f0638fb9R24): Added an import for the `CourseData` type from the `revision-tabs/revisionType` module to enhance type safety when handling course-related data.

### Functional Updates:
* [`src/components/dean-components/revision-review-components/ProgramRevisionReview.tsx`](diffhunk://#diff-c636d9151b2bb3b919d6e370bb90cf3d1ff4b7eae039e8ca41e9c111f0638fb9L652-R659): Updated the `coursesWithRevisions` prop in the `CourseRevisionTabs` component to include a mapped structure with a type assertion for `courseData` as `CourseData`. This ensures the data passed is properly typed and structured.