### PR TITLE
fix: wrap CourseDetailsTabs in TabsContent for proper layout

### DIFF
--- a/src/components/dean-components/revision-review-components/ProgramRevisionReview.tsx
+++ b/src/components/dean-components/revision-review-components/ProgramRevisionReview.tsx
@@ -600,13 +600,14 @@ export default function ProgramRevisionReview({
                 mappings={transformedData.course_po_mappings}
               />
             </TabsContent>
-
-            <CourseDetailsTabs
-              courses={programData?.curriculum?.courses || []}
-              courseDetailsMap={
-                dynamicCourseDetailsMap // Fallback to sample data if API data not available
-              }
-            />
+            <TabsContent value="courses" className="space-y-6">
+              <CourseDetailsTabs
+                courses={programData?.curriculum?.courses || []}
+                courseDetailsMap={
+                  dynamicCourseDetailsMap // Fallback to sample data if API data not available
+                }
+              />
+            </TabsContent>
           </Tabs>
         </div>
       ) : (


### PR DESCRIPTION
This pull request introduces a small enhancement to the `ProgramRevisionReview` component by adding a new `TabsContent` section for displaying course details. This change improves the user interface by organizing course-related information into a dedicated tab.

Key change:

* [`src/components/dean-components/revision-review-components/ProgramRevisionReview.tsx`](diffhunk://#diff-c636d9151b2bb3b919d6e370bb90cf3d1ff4b7eae039e8ca41e9c111f0638fb9L603-R610): Added a new `TabsContent` with the value `"courses"` to display course details using the `CourseDetailsTabs` component. This allows better separation and presentation of course information.