### PR TITLE
feat: enhance transformRevisionData to include department-level detai…

### DIFF
--- a/src/components/dean-components/ProgramReview.tsx
+++ b/src/components/dean-components/ProgramReview.tsx
@@ -627,7 +627,9 @@ export default function ProgramReviewPage({
   const transformRevisionData = (requests: RevisionRequest[]) => {
     const result: {
       status: string;
+
       department_level: Array<{ section: string; details: string }>;
+
       committee_level: Array<{
         curriculum_course_id: number;
         section: string;
@@ -642,7 +644,10 @@ export default function ProgramReviewPage({
     requests.forEach((request) => {
       if (request.type === "section") {
         // Handle program-level revisions
-        // ...
+        result.department_level.push({
+          section: request.section,
+          details: request.details,
+        });
       } else if (request.type === "course") {
         // Handle course-level revisions
         result.committee_level.push({


### PR DESCRIPTION
This pull request introduces changes to the `ProgramReviewPage` component to enhance the handling of revision data by splitting it into department-level and committee-level revisions. The changes improve the structure and clarity of revision data processing.

Enhancements to revision data handling:

* [`src/components/dean-components/ProgramReview.tsx`](diffhunk://#diff-5e165b9f348e985541f1d0734684cca5b5c77a89cd0816b6e531f36e7dd87d4aR630-R632): Added new fields, `department_level` and `committee_level`, to the `result` object in the `transformRevisionData` function to categorize revision requests more effectively.
* [`src/components/dean-components/ProgramReview.tsx`](diffhunk://#diff-5e165b9f348e985541f1d0734684cca5b5c77a89cd0816b6e531f36e7dd87d4aL645-R650): Updated the logic to populate the `department_level` array for program-level revisions, ensuring sections and details are explicitly stored.…ls in revision requests